### PR TITLE
Update bami.sh

### DIFF
--- a/bami.sh
+++ b/bami.sh
@@ -43,7 +43,7 @@ function readPdu() {
     while [ ${complete} -eq "0" ]; do
         line=`readLine`
         # End Of Message detected
-        if [ -z ${line} ]; then
+        if [ -z "${line}" ]; then
             complete=1
         else
             # Concat line read
@@ -57,13 +57,13 @@ function readPdu() {
 # the asterisk ami welcome message is not found.
 function login() {
     local welcome=`readLine`
-    if [ ${welcome} != "Asterisk Call Manager/1.1" ]; then
+    if [ "${welcome}" != "Asterisk Call Manager/1.1" ]; then
         error "Invalid peer. Not AMI."
         exit 255
     fi
     printf "Action: Login\r\nUsername: ${user}\r\nSecret: ${pass}\r\n\r\n"
     local response=`readPdu`
-    if [[ ! ${response} =~ Success ]]; then
+    if [[ ! "${response}" =~ Success ]]; then
         error "Could not login: ${response}"
         exit 254
     fi
@@ -76,8 +76,8 @@ login
 while [ true ]; do
     pdu=`readPdu`
     debug "${pdu}"
-    $regex="Event: *"
-    if [[ $pdu =~ $regex ]]; then
+    regex="Event: *"
+    if [[ "$pdu" =~ "$regex" ]]; then
         eventName=`echo ${pdu} | cut -d' ' -f2`
         case ${eventName} in
             DTMF)


### PR DESCRIPTION
Some bash warnings have been fixed. Originally the following messages appear (even everything was working fine):

ncat 127.0.0.1 5038 -c ./bami.sh
./bami.sh: line 60: [: too many arguments
./bami.sh: line 46: [: Response:: binary operator expected
./bami.sh: line 46: [: too many arguments
./bami.sh: line 46: [: Event:: binary operator expected
./bami.sh: line 46: [: Privilege:: binary operator expected
./bami.sh: line 46: [: too many arguments
./bami.sh: line 80: =Event: *: command not found
./bami.sh: line 46: [: Event:: binary operator expected
./bami.sh: line 46: [: Privilege:: binary operator expected
./bami.sh: line 46: [: ChannelType:: binary operator expected
./bami.sh: line 46: [: Username:: binary operator expected
./bami.sh: line 46: [: Domain:: binary operator expected
./bami.sh: line 46: [: Status:: binary operator expected
./bami.sh: line 80: =Event: *: command not found
./bami.sh: line 46: [: Event:: binary operator expected
./bami.sh: line 46: [: Privilege:: binary operator expected
./bami.sh: line 46: [: ChannelType:: binary operator expected